### PR TITLE
Skip failing pytests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
       # TODO: enable all pytests once passing locally
       # TODO: tapis auth init
       - name: Run pytests
-        run: python -m pytest tests
+        run: python -m pytest tests/test_000_imports.py
 
       # Build image and test default CMD
       - name: Generate env.DOCKER_TAGS and env.PRIMARY_TAG

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
       # TODO: enable all pytests once passing locally
       # TODO: tapis auth init
       - name: Run pytests
-        run: python -m pytest tests/test_000_imports.py
+        run: python -m pytest tests
 
       # Build image and test default CMD
       - name: Generate env.DOCKER_TAGS and env.PRIMARY_TAG

--- a/tests/test_001_reactors_init.py
+++ b/tests/test_001_reactors_init.py
@@ -67,6 +67,7 @@ def test_username_from_env(monkeypatch):
     assert r_uname == 'taco'
 
 
+@pytest.mark.skip
 def test_username_from_client():
     '''Can we pick up username from Agave.client'''
     from agavepy.agave import Agave
@@ -76,6 +77,7 @@ def test_username_from_client():
     assert local_uname == r.username
 
 
+@pytest.mark.skip
 def test_token_available():
     '''Can we pick up Oauth token'''
     r = Reactor()
@@ -97,6 +99,7 @@ def test_session(monkeypatch):
     assert r.session == 'slimy-eel'
 
 
+@pytest.mark.skip
 def test_session_env(monkeypatch):
     '''can we set up environment for messaging'''
     monkeypatch.setenv('SESSION', 'slimy-eel')
@@ -114,6 +117,7 @@ def test_session_autoname(monkeypatch):
     assert r.nickname == r.session
 
 
+@pytest.mark.skip
 def test_env_from_mock():
     '''Does the environment get populated in mock context'''
     r = Reactor()

--- a/tests/test_003_reactors_jsonmessages.py
+++ b/tests/test_003_reactors_jsonmessages.py
@@ -31,6 +31,7 @@ def test_validate_message_jsonschema():
                                permissive=False)
     assert valid is True
 
+@pytest.mark.skip
 def test_validate_message_jsonschema_throws_exception():
     '''Ensure ValidationError can be raised'''
     r = Reactor()
@@ -70,6 +71,7 @@ def test_find_schema_files():
 #     for sch in schemas:
 #         jsonmessages.get_schema_identifier(sch)
 
+@pytest.mark.skip
 def test_classify_simple_json_message():
     '''Test that simple JSON can be classified with the generic schema'''
     r = Reactor()
@@ -80,6 +82,7 @@ def test_classify_simple_json_message():
     assert 'abaco_json_message' in matches
 
 
+@pytest.mark.skip
 def test_classify_email_json_message():
     '''Test that an email message can be classified with the generic and email message schema'''
     r = Reactor()

--- a/tests/test_006_reactors_logs.py
+++ b/tests/test_006_reactors_logs.py
@@ -10,6 +10,7 @@ def test_read_logtoken_config():
     assert 'token' in r.settings.logs
 
 
+@pytest.mark.skip
 def test_read_logtoken_env(monkeypatch):
     '''Read the API token for log aggregation from environment'''
     monkeypatch.setenv('_REACTOR_LOGS_TOKEN', 'VewyVewySekwit')

--- a/tests/test_008_reactors_resolve_identifier.py
+++ b/tests/test_008_reactors_resolve_identifier.py
@@ -11,6 +11,7 @@ def test_linked_reactors_present():
     assert 'linked_reactors' in r.settings.keys()
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("self_alias", [('me'), ('self')])
 def test_resolve_valid_actor_id_me(self_alias):
     '''If passed an self-alias, return it'''
@@ -19,6 +20,7 @@ def test_resolve_valid_actor_id_me(self_alias):
     assert r.resolve_actor_alias(self_alias) == r.uid
 
 
+@pytest.mark.skip
 def test_resolve_valid_actor_id():
     '''If passed an actorID, return it'''
     valid_actor_id = 'OZYYyRpreyYBz'


### PR DESCRIPTION
Fixes #20.

Skip pytests that fail due to non-existent live fixtures such as deployed app, actor, log service, etc.